### PR TITLE
Fix an exception that occurred when attempting to clear outside the sheet range

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,8 +9,14 @@
 const clearColumnsFromTopLeft = ({sheet, topLeftRange, numCols} = {}) => {
   const startRow = topLeftRange.getRow();
   const startColumn = topLeftRange.getColumn();
-  const numRows = sheet.getMaxRows() - startRow + 1;
+  const maxRowCount = sheet.getMaxRows();
 
+  if (maxRowCount < startRow) {
+    console.log(`[Clear] No need to clear because the input value "topLeftRange" (${topLeftRange.getA1Notation()}) is outside the bounds of the sheet (maxRowCount: ${maxRowCount}).`);
+    return;
+  }
+
+  const numRows = maxRowCount - startRow + 1;
   const range = sheet.getRange(startRow, startColumn, numRows, numCols);
   console.log(`[Clear] ${range.getA1Notation()}`);
   range.clearContent();


### PR DESCRIPTION
## User description

<!-- If present, mention the related issue. -->

This PR will fix the following error:

<img width="728" alt="The error log" src="https://github.com/user-attachments/assets/47a0c96b-761f-444c-bea2-2ecbc792eb47" />

Added a guard clause to skip clearing when topLeftRange is outside the sheet’s row bounds. Also added a log message for better debugging.

## PR Type

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 80a9895efcfc760cb7f79f47eba42648f4db7c4c

['Bug fix']

## Description

<!-- Do not change this section. -->

### 🤖 Generated by PR Agent at 80a9895efcfc760cb7f79f47eba42648f4db7c4c

- Prevent exception when clearing outside sheet range
- Add bounds check for `topLeftRange` in `clearColumnsFromTopLeft`
- Log informative message when range is out of bounds


## Changes walkthrough 📝

<!-- Do not change this section. -->

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.js</strong><dd><code>Add bounds check to prevent clearing outside sheet range</code>&nbsp; </dd></summary>
<hr>

lib/util.js

<li>Added a check to ensure <code>topLeftRange</code> is within sheet bounds before <br>clearing<br> <li> Log a message and return early if the range is out of bounds<br> <li> Prevents exceptions when attempting to clear outside the sheet range


</details>


  </td>
  <td><a href="https://github.com/route06inc/ospo-google-apps-script/pull/13/files#diff-3fb720f70ea34fb2975fd6c38ac4b6b6131373be2abfa4760dfaae8a25daaee2">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>